### PR TITLE
fix: Support both DuckDuckGo response formats for JSON extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.4
+- Support both DuckDuckGo response formats for JSON extraction #6 
+
 ## 0.1.3
 - fix missing converter on properties
 

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -15,6 +15,3 @@ class RateLimitException extends DuckDuckGoSearchException {
 class TimeoutException extends DuckDuckGoSearchException {
   TimeoutException([super.message = 'request timeout']);
 }
-
-
-

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -5,7 +5,6 @@ import 'package:html/parser.dart' as htmlParser;
 import 'package:html_unescape/html_unescape_small.dart';
 import 'package:http/http.dart' as http;
 
-
 /// Normalizes a raw HTML string by stripping HTML tags and unescaping HTML entities.
 ///
 /// If the [rawHtml] parameter is `null` or an empty string, an empty string is returned.
@@ -22,7 +21,7 @@ import 'package:http/http.dart' as http;
 /// The normalized string with HTML tags removed and HTML entities unescaped.
 String normalize(String? rawHtml) {
   if (rawHtml == null || rawHtml.isEmpty) return "";
-  var parsedHtml  = htmlParser.parse(rawHtml).body?.text ?? '';
+  var parsedHtml = htmlParser.parse(rawHtml).body?.text ?? '';
   return parsedHtml;
 }
 
@@ -92,7 +91,6 @@ String _extractVqd(String respContent, String keywords) {
         '_extractVqd() failed to extract vqd for: $keywords');
   }
 }
-
 
 /// Extracts a list of dynamic objects from a JSON string within a larger string.
 ///

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -5,6 +5,7 @@ import 'package:html/parser.dart' as htmlParser;
 import 'package:html_unescape/html_unescape_small.dart';
 import 'package:http/http.dart' as http;
 
+
 /// Normalizes a raw HTML string by stripping HTML tags and unescaping HTML entities.
 ///
 /// If the [rawHtml] parameter is `null` or an empty string, an empty string is returned.
@@ -21,7 +22,7 @@ import 'package:http/http.dart' as http;
 /// The normalized string with HTML tags removed and HTML entities unescaped.
 String normalize(String? rawHtml) {
   if (rawHtml == null || rawHtml.isEmpty) return "";
-  var parsedHtml = htmlParser.parse(rawHtml).body?.text ?? '';
+  var parsedHtml  = htmlParser.parse(rawHtml).body?.text ?? '';
   return parsedHtml;
 }
 
@@ -54,7 +55,8 @@ String normalizeUrl(String? url) {
 /// Returns:
 ///   Future<String>: The VQD value as a string.
 Future<String> getVqd(String keywords) async {
-  var data = await http.post(Uri.parse('https://duckduckgo.com'), body: {'q': keywords});
+  var data = await http
+      .post(Uri.parse('https://duckduckgo.com'), body: {'q': keywords});
 
   return _extractVqd(data.body, keywords);
 }
@@ -86,9 +88,11 @@ String _extractVqd(String respContent, String keywords) {
     if (vqd == null) throw DuckDuckGoSearchException('vqd value is null');
     return vqd;
   } else {
-    throw DuckDuckGoSearchException('_extractVqd() failed to extract vqd for: $keywords');
+    throw DuckDuckGoSearchException(
+        '_extractVqd() failed to extract vqd for: $keywords');
   }
 }
+
 
 /// Extracts a list of dynamic objects from a JSON string within a larger string.
 ///
@@ -102,11 +106,11 @@ List<dynamic> textExtractJson(String content, String keywords) {
   int start = content.indexOf("DDG.pageLayout.load('d',") + 24;
   // int end = content.indexOf(");DDG.duckbar.load(", start);
 
-// End condition 1: );DDG.duckbar.load(
+  // End condition 1: );DDG.duckbar.load(
   int end1 = content.indexOf(");DDG.duckbar.load(", start);
-// End condition 2: );DDG.duckbar.loadModule(
+  // End condition 2: );DDG.duckbar.loadModule(
   int end2 = content.indexOf(");DDG.duckbar.loadModule(", start);
-// Select the earliest end position
+  // Select the earliest end position
   int end;
   if (end1 != -1 && (end2 == -1 || end1 < end2)) {
     end = end1;

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -5,7 +5,6 @@ import 'package:html/parser.dart' as htmlParser;
 import 'package:html_unescape/html_unescape_small.dart';
 import 'package:http/http.dart' as http;
 
-
 /// Normalizes a raw HTML string by stripping HTML tags and unescaping HTML entities.
 ///
 /// If the [rawHtml] parameter is `null` or an empty string, an empty string is returned.
@@ -22,7 +21,7 @@ import 'package:http/http.dart' as http;
 /// The normalized string with HTML tags removed and HTML entities unescaped.
 String normalize(String? rawHtml) {
   if (rawHtml == null || rawHtml.isEmpty) return "";
-  var parsedHtml  = htmlParser.parse(rawHtml).body?.text ?? '';
+  var parsedHtml = htmlParser.parse(rawHtml).body?.text ?? '';
   return parsedHtml;
 }
 
@@ -55,8 +54,7 @@ String normalizeUrl(String? url) {
 /// Returns:
 ///   Future<String>: The VQD value as a string.
 Future<String> getVqd(String keywords) async {
-  var data = await http
-      .post(Uri.parse('https://duckduckgo.com'), body: {'q': keywords});
+  var data = await http.post(Uri.parse('https://duckduckgo.com'), body: {'q': keywords});
 
   return _extractVqd(data.body, keywords);
 }
@@ -88,11 +86,9 @@ String _extractVqd(String respContent, String keywords) {
     if (vqd == null) throw DuckDuckGoSearchException('vqd value is null');
     return vqd;
   } else {
-    throw DuckDuckGoSearchException(
-        '_extractVqd() failed to extract vqd for: $keywords');
+    throw DuckDuckGoSearchException('_extractVqd() failed to extract vqd for: $keywords');
   }
 }
-
 
 /// Extracts a list of dynamic objects from a JSON string within a larger string.
 ///
@@ -104,7 +100,22 @@ String _extractVqd(String respContent, String keywords) {
 /// The extracted list is returned as a [List<dynamic>].
 List<dynamic> textExtractJson(String content, String keywords) {
   int start = content.indexOf("DDG.pageLayout.load('d',") + 24;
-  int end = content.indexOf(");DDG.duckbar.load(", start);
+  // int end = content.indexOf(");DDG.duckbar.load(", start);
+
+// End condition 1: );DDG.duckbar.load(
+  int end1 = content.indexOf(");DDG.duckbar.load(", start);
+// End condition 2: );DDG.duckbar.loadModule(
+  int end2 = content.indexOf(");DDG.duckbar.loadModule(", start);
+// Select the earliest end position
+  int end;
+  if (end1 != -1 && (end2 == -1 || end1 < end2)) {
+    end = end1;
+  } else if (end2 != -1) {
+    end = end2;
+  } else {
+    throw ArgumentError("End tag not found.");
+  }
+
   String data = content.substring(start, end);
   var aa = jsonDecode(data) as List<dynamic>;
   return aa;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: duckduckgo_search
 description: DuckDuckGo Search API for Dart
-version: 0.1.3
+version: 0.1.4
 repository: https://github.com/kingwill101/duckduckgo_search/
 
 environment:


### PR DESCRIPTION
### Problem
The DuckDuckGo response contains two possible end formats:
1. `);DDG.duckbar.load(`
2. `);DDG.duckbar.loadModule(`

However, the current implementation only supports the first format (`);DDG.duckbar.load(`). This results in cases where JSON cannot be extracted correctly if the response uses the second format (`);DDG.duckbar.loadModule(`).

### Solution
This PR updates the code to handle both formats. The implementation now selects the earliest occurrence of either end format, ensuring JSON extraction works regardless of which format is used.

### Changes
- Added support for the second end format: `);DDG.duckbar.loadModule(`.
- Implemented logic to choose the earliest end position between the two formats.
- Added a fallback error to handle cases where neither end format is found.
